### PR TITLE
remove event-aggregator dependency and update to latest aurelia

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ export function configure(aurelia) {
             config.setEnvironments({
                 development: ['localhost', 'dev.local'],
                 staging: ['staging.website.com', 'test.staging.website.com'],
-                production: ['website.com']  
+                production: ['website.com']
             });
         });
 
@@ -197,7 +197,7 @@ A method for setting dynamic environments. This method is designed to work withi
 config.setEnvironments({
     development: ['localhost', 'dev.local'],
     staging: ['staging.website.com', 'test.staging.website.com'],
-    production: ['website.com']  
+    production: ['website.com']
 });
 ```
 
@@ -248,7 +248,6 @@ var myConfigValues = config.getAll();
 
 * [aurelia-dependency-injection](https://github.com/aurelia/dependency-injection)
 * [aurelia-http-client](https://github.com/aurelia/http-client)
-* [aurelia-event-aggregator](https://github.com/aurelia/event-aggregator)
 
 ## Building from src
 

--- a/config.js
+++ b/config.js
@@ -16,42 +16,55 @@ System.config({
   },
 
   map: {
-    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.2",
-    "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.7.0",
-    "aurelia-http-client": "github:aurelia/http-client@0.10.3",
-    "babel": "npm:babel-core@5.8.23",
-    "babel-runtime": "npm:babel-runtime@5.8.20",
-    "core-js": "npm:core-js@1.1.3",
-    "github:aurelia/dependency-injection@0.9.2": {
-      "aurelia-logging": "github:aurelia/logging@0.6.4",
-      "aurelia-metadata": "github:aurelia/metadata@0.7.3",
+    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.11.2",
+    "aurelia-http-client": "github:aurelia/http-client@0.12.0",
+    "babel": "npm:babel-core@5.8.25",
+    "babel-runtime": "npm:babel-runtime@5.8.25",
+    "core-js": "npm:core-js@0.9.18",
+    "github:aurelia/dependency-injection@0.11.2": {
+      "aurelia-logging": "github:aurelia/logging@0.8.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.9.0",
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/event-aggregator@0.7.0": {
-      "aurelia-logging": "github:aurelia/logging@0.6.4"
-    },
-    "github:aurelia/http-client@0.10.3": {
-      "aurelia-path": "github:aurelia/path@0.8.1",
+    "github:aurelia/http-client@0.12.0": {
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
+      "aurelia-path": "github:aurelia/path@0.10.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/metadata@0.7.3": {
+    "github:aurelia/metadata@0.9.0": {
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:jspm/nodelibs-process@0.1.1": {
-      "process": "npm:process@0.10.1"
+    "github:jspm/nodelibs-assert@0.1.0": {
+      "assert": "npm:assert@1.3.0"
     },
-    "npm:babel-runtime@5.8.20": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
+    },
+    "github:jspm/nodelibs-util@0.1.0": {
+      "util": "npm:util@0.10.3"
+    },
+    "npm:assert@1.3.0": {
+      "util": "npm:util@0.10.3"
+    },
+    "npm:babel-runtime@5.8.25": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
-    "npm:core-js@1.1.3": {
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    "npm:inherits@2.0.1": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:util@0.10.3": {
+      "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
       "lib": "dist/amd"
     },
     "dependencies": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.9.2",
-      "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.7.0",
-      "aurelia-http-client": "github:aurelia/http-client@^0.10.3",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.11.2",
+      "aurelia-http-client": "github:aurelia/http-client@^0.12.0",
       "core-js": "npm:core-js@^0.9.4"
     },
     "devDependencies": {

--- a/src/configure.js
+++ b/src/configure.js
@@ -2,7 +2,6 @@ import 'core-js';
 
 import {inject} from 'aurelia-dependency-injection';
 import {HttpClient} from 'aurelia-http-client';
-import {EventAggregator} from 'aurelia-event-aggregator';
 
 // Secure references that can't be changed outside of Configure singleton class
 const ENVIRONMENT = new WeakMap();
@@ -12,12 +11,11 @@ const CONFIG_FILE = new WeakMap();
 const CONFIG_OBJECT = new WeakMap();
 const CASCADE_MODE = new WeakMap();
 
-@inject(HttpClient, EventAggregator)
+@inject(HttpClient)
 export class Configure {
-    constructor(http, ea) {
+    constructor(http) {
         // Injected dependencies
         this.http = http;
-        this.ea = ea;
 
         CONFIG_OBJECT.set(this, {});
 
@@ -277,6 +275,10 @@ export class Configure {
             let splitKey = key.split('.');
             let parent = splitKey[0];
             let child = splitKey[1];
+
+            if (this.obj[parent] === undefined) {
+              this.obj[parent] = {};
+            }
 
             this.obj[parent][child] = val;
         }

--- a/test/configure.spec.js
+++ b/test/configure.spec.js
@@ -6,19 +6,13 @@ class HttpStub {
     }
 }
 
-class EventStub {
-
-}
-
 describe('configure.js -- ', () => {
     var config;
     var mockedHttp;
-    var mockedEvent;
 
     beforeEach(() => {
         mockedHttp = new HttpStub();
-        mockedEvent = new EventStub();
-        config = new Configure(mockedHttp, mockedEvent);
+        config = new Configure(mockedHttp);
 
         spyOn(config, 'loadConfig').and.callFake(() => {
             return new Promise((resolve, reject) => {
@@ -47,7 +41,6 @@ describe('configure.js -- ', () => {
 
         it('constructor should inject classes', () => {
             expect(config.http).toBeDefined();
-            expect(config.ea).toBeDefined();
         });
 
         it('loadConfig method should have been called', () => {


### PR DESCRIPTION
Hi! I was updating our app to latest aurelia and wanted to update the dependencies.

I removed event-aggregator since I could not see where it was being used..

Also, a test was failing so I fixed up the code to make it pass..  not sure if it is what you wanted, so just let me know if you want me to revert that part.