### PR TITLE
chore(README): Commata fix in json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If a value is not found inside of a configuration group, it will attempt to look
         "api": {
             "key": "developmentonlykey938109283091",
             "endpoint": "http://localhost/api/v1"
-        },
+        }
     }
 }
 ```


### PR DESCRIPTION
That wrong commata can cause problems for those extremely lazy people like me who just copy stuff together to get a quick example going ;)