### PR TITLE
fix(environment-selection): Update environment selection

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -139,6 +139,9 @@ export class Configure {
                     for (let host of hostnames) {
                         if (hostname.search(host) !== -1) {
                             this.setEnvironment(env);
+                            
+                            // We have successfully found an environment, stop searching
+                            return;
                         }
                     }
                 }


### PR DESCRIPTION
Once an environment has been found, we should stop searching for environments. I had an issue where I had:

staging: staging.domain.com
production: domain.com

When browsing on staging, it matched staging but then also matched production because "domain.com" was found in the hostname "staging.domain.com". I believe that line 140 should check for string equality rather than contains, which would alleviate this. However, adding in the return statement leaves this control up to the user of this plugin because you can set the ordering of the environments to get around it.