### PR TITLE
guard loadText callback parse

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -333,7 +333,9 @@ export class Configure {
         
         return this.loader.loadText(pathClosure)
             .then(data => {
-                data = JSON.parse(data);
+                if (typeof data !== 'object') {
+                    data = JSON.parse(data);
+                }
                 action(data);
             })
             .catch(() => { 


### PR DESCRIPTION
the `loadText` callback parses the config file's (textual) data to an object. in a webpack setup (with json-loader), this callback is passed with a plain object, and the parsing fails.
as result, the `loadConfig` promise is rejected and throws 'Configuration file could not be loaded'.

this fixes webpack setups by guarding the parse in `loadText` with a type check.