### PR TITLE
guard loadText callback parse

### DIFF
--- a/dist/amd/aurelia-configuration.js
+++ b/dist/amd/aurelia-configuration.js
@@ -98,7 +98,7 @@ define(['exports', 'deep-extend', 'aurelia-dependency-injection', 'aurelia-path'
         };
 
         Configure.prototype.environmentExists = function environmentExists() {
-            return typeof this.obj[this.environment] === undefined ? false : true;
+            return this.environment in this.obj;
         };
 
         Configure.prototype.get = function get(key) {
@@ -110,13 +110,11 @@ define(['exports', 'deep-extend', 'aurelia-dependency-injection', 'aurelia-path'
                 if (!this.environmentEnabled()) {
                     return this.obj[key] ? this.obj[key] : defaultValue;
                 } else {
-                    if (this.environmentExists()) {
-                        if (this.obj[this.environment][key]) {
-                            returnVal = this.obj[this.environment][key];
-                        } else if (this.cascadeMode && this.obj[key]) {
-                                returnVal = this.obj[key];
-                            }
-                    }
+                    if (this.environmentExists() && this.obj[this.environment][key]) {
+                        returnVal = this.obj[this.environment][key];
+                    } else if (this.cascade_mode && this.obj[key]) {
+                            returnVal = this.obj[key];
+                        }
 
                     return returnVal;
                 }
@@ -133,7 +131,7 @@ define(['exports', 'deep-extend', 'aurelia-dependency-injection', 'aurelia-path'
                     if (this.environmentExists()) {
                         if (this.obj[this.environment][_parent] && this.obj[this.environment][_parent][child]) {
                             returnVal = this.obj[this.environment][_parent][child];
-                        } else if (this.cascadeMode && this.obj[_parent] && this.obj[_parent][child]) {
+                        } else if (this.cascade_mode && this.obj[_parent] && this.obj[_parent][child]) {
                             returnVal = this.obj[_parent][child];
                         }
                     }
@@ -198,7 +196,9 @@ define(['exports', 'deep-extend', 'aurelia-dependency-injection', 'aurelia-path'
             var pathClosure = path.toString();
 
             return this.loader.loadText(pathClosure).then(function (data) {
-                data = JSON.parse(data);
+                if (typeof data !== 'object') {
+                    data = JSON.parse(data);
+                }
                 action(data);
             })['catch'](function () {
                 console.log('Configuration file could not be found or loaded: ' + pathClosure);

--- a/dist/aurelia-configuration.js
+++ b/dist/aurelia-configuration.js
@@ -169,7 +169,7 @@ export class Configure {
      * @returns {boolean}
      */
     environmentExists() {
-        return (typeof this.obj[this.environment] === undefined) ? false : true;
+        return this.environment in this.obj;
     }
 
     /**
@@ -191,14 +191,12 @@ export class Configure {
             if (!this.environmentEnabled()) {
                 return this.obj[key] ? this.obj[key] : defaultValue;
             } else {
-                if (this.environmentExists()) {
-                    // Value exists in environment
-                    if (this.obj[this.environment][key]) {
-                        returnVal = this.obj[this.environment][key];
-                    // Get default value from non-namespaced section if enabled
-                    } else if (this.cascadeMode && this.obj[key]) {
-                        returnVal = this.obj[key];
-                    }
+                // Value exists in environment
+                if (this.environmentExists() && this.obj[this.environment][key]) {
+                    returnVal = this.obj[this.environment][key];
+                // Get default value from non-namespaced section if enabled
+                } else if (this.cascade_mode && this.obj[key]) {
+                    returnVal = this.obj[key];
                 }
 
                 return returnVal;
@@ -216,7 +214,7 @@ export class Configure {
                 if (this.environmentExists()) {
                     if (this.obj[this.environment][parent] && this.obj[this.environment][parent][child]) {
                         returnVal = this.obj[this.environment][parent][child];
-                    } else if (this.cascadeMode && this.obj[parent] && this.obj[parent][child]) {
+                    } else if (this.cascade_mode && this.obj[parent] && this.obj[parent][child]) {
                         returnVal = this.obj[parent][child];
                     }
                 }
@@ -335,7 +333,9 @@ export class Configure {
         
         return this.loader.loadText(pathClosure)
             .then(data => {
-                data = JSON.parse(data);
+                if (typeof data !== 'object') {
+                    data = JSON.parse(data);
+                }
                 action(data);
             })
             .catch(() => { 

--- a/dist/commonjs/aurelia-configuration.js
+++ b/dist/commonjs/aurelia-configuration.js
@@ -105,7 +105,7 @@ var Configure = (function () {
     };
 
     Configure.prototype.environmentExists = function environmentExists() {
-        return typeof this.obj[this.environment] === undefined ? false : true;
+        return this.environment in this.obj;
     };
 
     Configure.prototype.get = function get(key) {
@@ -117,13 +117,11 @@ var Configure = (function () {
             if (!this.environmentEnabled()) {
                 return this.obj[key] ? this.obj[key] : defaultValue;
             } else {
-                if (this.environmentExists()) {
-                    if (this.obj[this.environment][key]) {
-                        returnVal = this.obj[this.environment][key];
-                    } else if (this.cascadeMode && this.obj[key]) {
-                            returnVal = this.obj[key];
-                        }
-                }
+                if (this.environmentExists() && this.obj[this.environment][key]) {
+                    returnVal = this.obj[this.environment][key];
+                } else if (this.cascade_mode && this.obj[key]) {
+                        returnVal = this.obj[key];
+                    }
 
                 return returnVal;
             }
@@ -140,7 +138,7 @@ var Configure = (function () {
                 if (this.environmentExists()) {
                     if (this.obj[this.environment][_parent] && this.obj[this.environment][_parent][child]) {
                         returnVal = this.obj[this.environment][_parent][child];
-                    } else if (this.cascadeMode && this.obj[_parent] && this.obj[_parent][child]) {
+                    } else if (this.cascade_mode && this.obj[_parent] && this.obj[_parent][child]) {
                         returnVal = this.obj[_parent][child];
                     }
                 }
@@ -205,7 +203,9 @@ var Configure = (function () {
         var pathClosure = path.toString();
 
         return this.loader.loadText(pathClosure).then(function (data) {
-            data = JSON.parse(data);
+            if (typeof data !== 'object') {
+                data = JSON.parse(data);
+            }
             action(data);
         })['catch'](function () {
             console.log('Configuration file could not be found or loaded: ' + pathClosure);

--- a/dist/es6/aurelia-configuration.js
+++ b/dist/es6/aurelia-configuration.js
@@ -169,7 +169,7 @@ export class Configure {
      * @returns {boolean}
      */
     environmentExists() {
-        return (typeof this.obj[this.environment] === undefined) ? false : true;
+        return this.environment in this.obj;
     }
 
     /**
@@ -191,14 +191,12 @@ export class Configure {
             if (!this.environmentEnabled()) {
                 return this.obj[key] ? this.obj[key] : defaultValue;
             } else {
-                if (this.environmentExists()) {
-                    // Value exists in environment
-                    if (this.obj[this.environment][key]) {
-                        returnVal = this.obj[this.environment][key];
-                    // Get default value from non-namespaced section if enabled
-                    } else if (this.cascadeMode && this.obj[key]) {
-                        returnVal = this.obj[key];
-                    }
+                // Value exists in environment
+                if (this.environmentExists() && this.obj[this.environment][key]) {
+                    returnVal = this.obj[this.environment][key];
+                // Get default value from non-namespaced section if enabled
+                } else if (this.cascade_mode && this.obj[key]) {
+                    returnVal = this.obj[key];
                 }
 
                 return returnVal;
@@ -216,7 +214,7 @@ export class Configure {
                 if (this.environmentExists()) {
                     if (this.obj[this.environment][parent] && this.obj[this.environment][parent][child]) {
                         returnVal = this.obj[this.environment][parent][child];
-                    } else if (this.cascadeMode && this.obj[parent] && this.obj[parent][child]) {
+                    } else if (this.cascade_mode && this.obj[parent] && this.obj[parent][child]) {
                         returnVal = this.obj[parent][child];
                     }
                 }
@@ -335,7 +333,9 @@ export class Configure {
         
         return this.loader.loadText(pathClosure)
             .then(data => {
-                data = JSON.parse(data);
+                if (typeof data !== 'object') {
+                    data = JSON.parse(data);
+                }
                 action(data);
             })
             .catch(() => { 

--- a/dist/system/aurelia-configuration.js
+++ b/dist/system/aurelia-configuration.js
@@ -121,7 +121,7 @@ System.register(['deep-extend', 'aurelia-dependency-injection', 'aurelia-path', 
                 };
 
                 Configure.prototype.environmentExists = function environmentExists() {
-                    return typeof this.obj[this.environment] === undefined ? false : true;
+                    return this.environment in this.obj;
                 };
 
                 Configure.prototype.get = function get(key) {
@@ -133,13 +133,11 @@ System.register(['deep-extend', 'aurelia-dependency-injection', 'aurelia-path', 
                         if (!this.environmentEnabled()) {
                             return this.obj[key] ? this.obj[key] : defaultValue;
                         } else {
-                            if (this.environmentExists()) {
-                                if (this.obj[this.environment][key]) {
-                                    returnVal = this.obj[this.environment][key];
-                                } else if (this.cascadeMode && this.obj[key]) {
-                                        returnVal = this.obj[key];
-                                    }
-                            }
+                            if (this.environmentExists() && this.obj[this.environment][key]) {
+                                returnVal = this.obj[this.environment][key];
+                            } else if (this.cascade_mode && this.obj[key]) {
+                                    returnVal = this.obj[key];
+                                }
 
                             return returnVal;
                         }
@@ -156,7 +154,7 @@ System.register(['deep-extend', 'aurelia-dependency-injection', 'aurelia-path', 
                             if (this.environmentExists()) {
                                 if (this.obj[this.environment][_parent] && this.obj[this.environment][_parent][child]) {
                                     returnVal = this.obj[this.environment][_parent][child];
-                                } else if (this.cascadeMode && this.obj[_parent] && this.obj[_parent][child]) {
+                                } else if (this.cascade_mode && this.obj[_parent] && this.obj[_parent][child]) {
                                     returnVal = this.obj[_parent][child];
                                 }
                             }
@@ -221,7 +219,9 @@ System.register(['deep-extend', 'aurelia-dependency-injection', 'aurelia-path', 
                     var pathClosure = path.toString();
 
                     return this.loader.loadText(pathClosure).then(function (data) {
-                        data = JSON.parse(data);
+                        if (typeof data !== 'object') {
+                            data = JSON.parse(data);
+                        }
                         action(data);
                     })['catch'](function () {
                         console.log('Configuration file could not be found or loaded: ' + pathClosure);

--- a/src/configure.js
+++ b/src/configure.js
@@ -333,7 +333,9 @@ export class Configure {
         
         return this.loader.loadText(pathClosure)
             .then(data => {
-                data = JSON.parse(data);
+                if (typeof data !== 'object') {
+                    data = JSON.parse(data);
+                }
                 action(data);
             })
             .catch(() => { 


### PR DESCRIPTION
the `loadText` callback parses the config file's (textual) data to an object. in a webpack setup (with json-loader), this callback is passed with a plain object, and the parsing fails.
as result, the `loadConfig` promise is rejected and throws 'Configuration file could not be loaded'.

this fixes webpack setups by guarding the parse in `loadText` with a type check.