### PR TITLE
expose jspm dependencies for webpack setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,17 +28,19 @@
     "directories": {
       "lib": "dist/amd"
     },
-    "peerDependencies": {
+    "dependencies": {
       "aurelia-dependency-injection": "^1.0.0-beta.1.1.4",
       "aurelia-loader": "1.0.0-beta.1.2.0",
-      "aurelia-path": "^1.0.0-beta.1.1.0",
-      "deep-extend": "^0.4.1"
+      "aurelia-path": "^1.0.0-beta.1.1.0"
     },
     "devDependencies": {
       "babel": "^5.8.24",
       "babel-runtime": "^5.8.24",
       "core-js": "^2.0.3"
     }
+  },
+  "dependencies": {
+    "deep-extend": "^0.4.1"
   },
   "devDependencies": {
     "aurelia-tools": "0.1.16",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "directories": {
       "lib": "dist/amd"
     },
-    "dependencies": {
+    "peerDependencies": {
       "aurelia-dependency-injection": "^1.0.0-beta.1.1.4",
       "aurelia-loader": "1.0.0-beta.1.2.0",
       "aurelia-path": "^1.0.0-beta.1.1.0",


### PR DESCRIPTION
expose only deep-extend as direct npm dependency (and not via jspm dependencies), to fix webpack setups.

webpack bundles aurelia-configuration using the npm dependencies, and so the (required) deep-extend is missing and the bundle fails.

this fixes a regression introduced [here](https://github.com/Vheissu/Aurelia-Configuration/commit/164077386af7be6b757c07d6af3ce838bbbe914c).
 