### PR TITLE
Checks for existence of overrideMimeType function on XMLHttpRequest.

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -329,7 +329,9 @@ export class Configure {
             let pathClosure = path.toString();
 
             let xhr = new XMLHttpRequest();
-            xhr.overrideMimeType('application/json');
+            if (xhr.overrideMimeType) {
+                xhr.overrideMimeType('application/json');
+            }
             xhr.open('GET', pathClosure, true);
 
             xhr.onreadystatechange = function() {


### PR DESCRIPTION
This function does not exist in <IE10, which breaks Aurelia application on IE10 browsers. Initial checks seem to indicate that the app works fine with this code change.