### PR TITLE
fixes promise handling in configure function

### DIFF
--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -8,17 +8,16 @@ define(['exports', './configure'], function (exports, _configure) {
     exports.configure = configure;
     function configure(aurelia, configCallback) {
         var instance = aurelia.container.get(_configure.Configure);
+        var promise = null;
 
         if (configCallback !== undefined && typeof configCallback === 'function') {
-            configCallback(instance);
+            promise = Promise.resolve(configCallback(instance));
         }
 
-        return new Promise(function (resolve, reject) {
-            instance.loadConfig().then(function () {
-                return resolve();
-            }).catch(function () {
-                reject(new Error('Configuration file could not be loaded'));
-            });
+        return promise.then(function () {
+            return instance.loadConfig();
+        }).catch(function () {
+            reject(new Error('Configuration file could not be loaded'));
         });
     }
 

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -10,17 +10,16 @@ var _configure = require('./configure');
 
 function configure(aurelia, configCallback) {
     var instance = aurelia.container.get(_configure.Configure);
+    var promise = null;
 
     if (configCallback !== undefined && typeof configCallback === 'function') {
-        configCallback(instance);
+        promise = Promise.resolve(configCallback(instance));
     }
 
-    return new Promise(function (resolve, reject) {
-        instance.loadConfig().then(function () {
-            return resolve();
-        }).catch(function () {
-            reject(new Error('Configuration file could not be loaded'));
-        });
+    return promise.then(function () {
+        return instance.loadConfig();
+    }).catch(function () {
+        reject(new Error('Configuration file could not be loaded'));
     });
 }
 

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -2,15 +2,16 @@ import { Configure } from './configure';
 
 export function configure(aurelia, configCallback) {
     let instance = aurelia.container.get(Configure);
+    let promise = null;
 
     if (configCallback !== undefined && typeof configCallback === 'function') {
-        configCallback(instance);
+        promise = Promise.resolve(configCallback(instance));
     }
 
-    return new Promise((resolve, reject) => {
-        instance.loadConfig().then(() => resolve()).catch(() => {
-            reject(new Error('Configuration file could not be loaded'));
-        });
+    return promise.then(function () {
+        return instance.loadConfig();
+    }).catch(function () {
+        reject(new Error('Configuration file could not be loaded'));
     });
 }
 

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -6,17 +6,16 @@ System.register(['./configure'], function (_export, _context) {
     var Configure;
     function configure(aurelia, configCallback) {
         var instance = aurelia.container.get(Configure);
+        var promise = null;
 
         if (configCallback !== undefined && typeof configCallback === 'function') {
-            configCallback(instance);
+            promise = Promise.resolve(configCallback(instance));
         }
 
-        return new Promise(function (resolve, reject) {
-            instance.loadConfig().then(function () {
-                return resolve();
-            }).catch(function () {
-                reject(new Error('Configuration file could not be loaded'));
-            });
+        return promise.then(function () {
+            return instance.loadConfig();
+        }).catch(function () {
+            reject(new Error('Configuration file could not be loaded'));
         });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,19 +2,21 @@ import {Configure} from './configure';
 
 export function configure(aurelia, configCallback) {
     let instance = aurelia.container.get(Configure);
+    let promise = null;
 
     // Do we have a callback function?
     if (configCallback !== undefined && typeof(configCallback) === 'function') {
-        configCallback(instance);
+        promise = Promise.resolve(configCallback(instance));
     }
 
-    return new Promise((resolve, reject) => {
-        instance.loadConfig()
-            .then(() => resolve())
-            .catch(() => {
-                reject(new Error('Configuration file could not be loaded'));
-            });
-    });
+    // Don't load the config until the configCallback has completed.
+    return promise
+        .then(function () {
+            return instance.loadConfig();
+        })
+        .catch(function () {
+            reject(new Error('Configuration file could not be loaded'));
+        });
 }
 
 export {Configure};


### PR DESCRIPTION
I thought I already had a PR for this, but must not be remembering correctly. Anyway...

The `configure` function was not returning the promise which is returned from `loadConfig`. This causes issues where merged config files would not end up in the final config (depending on timing). This could potentially have caused other issues as well.